### PR TITLE
using sharejs doc on server side when saving

### DIFF
--- a/public/js/application.js
+++ b/public/js/application.js
@@ -76,9 +76,7 @@ function DocsManager() {
     this.compileAndRender = function(documentId, documentName) {
         // first try to save the current document being displayed
         $.ajax({type: "POST"
-                , data: {"documentId" : documentId
-                         , "documentName" : documentName
-                         , "documentText": currentDoc.getText()}
+                , data: {"documentId" : documentId}
                 , url: "/savedoc"
                 , success: function(response) {
                     // update alerts
@@ -499,9 +497,7 @@ function DocsManager() {
     this.saveDoc = function(docId, docName) {
         // save the document
         $.ajax({type: "POST"
-                , data: {"documentId" : docId
-                         , "documentName" : docName
-                         , "documentText": currentDoc.getText()}
+                , data: {"documentId" : docId}
                 , url: "/savedoc"
                 , success: function(response) {
                     // update alerts


### PR DESCRIPTION
The current implementation posts the whole text when saving a document whilst it could be better to actually use the sharejs version on the server side.
In this way you would be able to speed up the operation and save on the amount of data transferred.
